### PR TITLE
 add depth parameters for NaViT calling and solve TypeError: meshgrid() got an unexpected keyword argument 'indexing'

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ n = NaViT(
     patch_size = 32,
     num_classes = 1000,
     dim = 1024,
+    depth=3,   # add depth parameters
     heads = 16,
     mlp_dim=2048,
     dropout=0.1,

--- a/navit/main.py
+++ b/navit/main.py
@@ -300,7 +300,10 @@ class NaViT(nn.Module):
                 pos = torch.stack(torch.meshgrid((
                     arange(ph),
                     arange(pw)
-                ), indexing = 'ij'), dim = -1)
+                # TypeError: meshgrid() got an unexpected keyword argument 'indexing'
+                # test with torch 1.9.0
+                # ), indexing = 'ij'), dim = -1)
+                )), dim = -1)
 
                 pos = rearrange(pos, 'h w c -> (h w) c')
                 seq = rearrange(image, 'c (h p1) (w p2) -> (h w) (c p1 p2)', p1 = p, p2 = p)


### PR DESCRIPTION
##  add depth parameters

```python

n = NaViT(
    image_size = 256,
    patch_size = 32,
    num_classes = 1000,
    dim = 1024,
    depth=3,   # add depth parameters
    heads = 16,
    mlp_dim=2048,
    dropout=0.1,
    emb_dropout=0.1,
    token_dropout_prob=0.1
)
```

## solve TypeError: meshgrid() got an unexpected keyword argument 'indexing'

```python

                pos = torch.stack(torch.meshgrid((
                    arange(ph),
                    arange(pw)
                # TypeError: meshgrid() got an unexpected keyword argument 'indexing'
                # test with torch 1.9.0
                # ), indexing = 'ij'), dim = -1)
                )), dim = -1)

```